### PR TITLE
certificate.py: add new compatible TaskExecutor signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ Installation:
 
     ansible-galaxy collection install community.crypto
 
-**Ansible versions before 2.10.0 are not supported, as the usage of other collections is not working**
+**Supported ansible-core versions: 2.17.x through 2.19.x (and newer)**
+
+Note: ansible-core versions before 2.10.0 are not supported, as the usage of other collections is not working.
 
 The below requirements are needed on the host that executes this module.
 
+- Python >= 3.11 (for control node with ansible-core >= 2.18)
+- Python >= 3.10 (for control node with ansible-core 2.17)
 - PyOpenSSL >= 0.15 or cryptography >= 1.6
 - OpenSSL binary in $PATH (only on CA Host)
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: mgit_at
 name: mgssl
-version: 2.1.6
+version: 2.1.7
 readme: README.md
 authors:
   - Patrick Pichler <ppichler@mgit.at>

--- a/plugins/action/certificate.py
+++ b/plugins/action/certificate.py
@@ -267,12 +267,12 @@ class ActionModule(ActionBase):
             task_vars.update(self._task.get_variable_manager().get_vars(host=host, task=task))
 
             try:
+                # Try new signature first (ansible-core 2.18+)
                 executor_result = TaskExecutor(
                     host,
                     task,
                     task_vars,
                     self._play_context,
-                    None,
                     self._loader,
                     self._shared_loader_obj,
                     None,
@@ -280,18 +280,33 @@ class ActionModule(ActionBase):
                 )
             except TypeError:
                 try:
+                    # Fall back to old signature (ansible-core < 2.18)
                     executor_result = TaskExecutor(
                         host,
                         task,
                         task_vars,
                         self._play_context,
-                        None,
+                        None,  # new_stdin (deprecated)
                         self._loader,
                         self._shared_loader_obj,
-                        None
+                        None,  # rslt_q
+                        self._task.get_variable_manager()
                     )
-                except Exception:
-                    raise TypeError("TaskExecutor: Wrong type of object") from None
+                except TypeError:
+                    # Even older signature without variable_manager
+                    try:
+                        executor_result = TaskExecutor(
+                            host,
+                            task,
+                            task_vars,
+                            self._play_context,
+                            None,
+                            self._loader,
+                            self._shared_loader_obj,
+                            None
+                        )
+                    except Exception:
+                        raise TypeError("TaskExecutor: Wrong type of object") from None
 
             # Dirty fix for mitogen compatibility
             # Mitogen somehow puts a task global connection binding object in each connection that gets created


### PR DESCRIPTION
- update signature of TaskExecutor to support ansible-core 2.18+